### PR TITLE
Fix: add MySQL authentication flags to first ALTER USER command in erpnext_install.sh

### DIFF
--- a/erpnext_install.sh
+++ b/erpnext_install.sh
@@ -475,7 +475,7 @@ if [ ! -f "$MARKER_FILE" ]; then
     echo -e "${YELLOW}Now we'll go ahead to apply MariaDB security settings...${NC}"
     sleep 2
 
-    sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$sqlpasswrd';"
+    sudo mysql -u root -p"$sqlpasswrd" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$sqlpasswrd';"
     sudo mysql -u root -p"$sqlpasswrd" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$sqlpasswrd';"
     sudo mysql -u root -p"$sqlpasswrd" -e "DELETE FROM mysql.user WHERE User='';"
     sudo mysql -u root -p"$sqlpasswrd" -e "DROP DATABASE IF EXISTS test; DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';"


### PR DESCRIPTION
The unattended install script failed on the first ALTER USER command if MariaDB root already had a password, because it did not include the -u root -p"$sqlpasswrd" flags.

This change updates the first ALTER USER command to include the authentication flags, making it consistent with the rest of the script.

Fixes #66